### PR TITLE
[Feature & update] gClickable attribute & preventing layout trashing

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,27 @@ limitations under the License.
       position: fixed;
     }
 
+    #btn0{
+      background-color: green;
+      top: 100px;
+      left : 652px;
+    }
+    #btn1{
+      background-color: purple;
+      top: 400px;
+      left : 542px;
+    }
+    #btn2{
+      background-color: pink;
+      top: 320px;
+      left : 102px;
+    }
+    #btn3{
+      background-color: plum;
+      top: 0px;
+      left : 10px;
+    }
+
   </style>
 </head>
 <body>
@@ -75,7 +96,17 @@ limitations under the License.
 
       <div id="pin" style="border-radius: 50%; background-color: yellow; width: 30px; height: 30px; position: absolute;"></div>
 
+
+      <div>
+        <button id="btn0" class="btn" gClickable onclick="alert('clicked!')">Click ME!!!</button>
+        <div>
+          <button id="btn1" class="btn" gClickable>Click ME!!!</button>
+        </div>
+        <button id="btn2" class="btn" gClickable>Click ME!!!</button>
+      </div>
+
       <div class="canvas-wrapper">
+        <button  class="btn" gClickable>Click ME!!!</button>
         <canvas id="output" style="z-index: 9999;"></canvas>
         <video id="video" playsinline style="
           -webkit-transform: scaleX(-1);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xr-touch",
+  "name": "v-gesture",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -21,6 +21,7 @@
     "@tensorflow/tfjs-converter": "^4.19.0",
     "@tensorflow/tfjs-core": "^4.19.0",
     "add": "^2.0.6",
+    "fastdom": "^1.0.12",
     "scatter-gl": "^0.0.13",
     "three": "^0.164.1"
   },

--- a/src/KDTree.ts
+++ b/src/KDTree.ts
@@ -1,11 +1,11 @@
-import { Boundary, Point, Vector2D, Vector3D } from './types'
+import { Boundary, Point, Vector2D, Vector3D, ElementBoundary } from './types'
 import { getRawDistance, getCloserDistance } from './math'
-
 
 const MAXIMUM_SUPPORTED_DIMENSION = 3;
 export class KDTree {
-  data: Boundary[];
-  root: Boundary
+  id: string;
+  data: ElementBoundary[];
+  root: ElementBoundary
   left: KDTree | null = null;
   right: KDTree | null = null;
   size: number;
@@ -15,18 +15,24 @@ export class KDTree {
   m: number;
 
 
-  constructor(data: Boundary[], dimension = 2, depth = 0) {
+  constructor(data: ElementBoundary[], dimension?: number);
+  constructor(data: ElementBoundary[], dimension = 2, _depth = 0) {
 
     if (dimension > MAXIMUM_SUPPORTED_DIMENSION) {
       throw new Error('Unable to construct K-d tree. Unsupported Dimension');
     }
-    this.depth = depth;
+
+    this.data = data;
+    this.depth = _depth;
     this.dimension = dimension;
-    this.axis = depth % dimension;
-    this.data = sort(data, this.axis);
-    this.size = data.length;
+    this.axis = _depth % dimension;
+    this.data = sort(this.data, this.axis);
+    this.size = this.data.length;
     this.m = Math.floor(data.length / 2);
     this.root = this.data[this.m];
+    this.id = this.root.id;
+
+
     if (this.m > 0) {
       this.left = new KDTree(this.data.slice(0, this.m), this.depth + 1)
     }
@@ -37,24 +43,23 @@ export class KDTree {
 
   emit(pivot: Vector2D | Vector3D) {
     const closestNode = this.searchClosest(pivot)
-
     if (closestNode) {
-      if (pivot[0] >= closestNode[0] - closestNode[2] &&
-        pivot[0] <= closestNode[0] + closestNode[2] &&
-        pivot[1] >= closestNode[1] - closestNode[3] &&
-        pivot[1] <= closestNode[1] + closestNode[3]
+      if (pivot[0] >= closestNode.boundary[0] - closestNode.boundary[2] &&
+        pivot[0] <= closestNode.boundary[0] + closestNode.boundary[2] &&
+        pivot[1] >= closestNode.boundary[1] - closestNode.boundary[3] &&
+        pivot[1] <= closestNode.boundary[1] + closestNode.boundary[3]
       ) {
-        return closestNode[4]
+        return closestNode.id
       }
     }
     return null
   }
 
   searchClosest(pivot: Vector2D | Vector3D) {
-    return this._search(this, pivot) as Boundary;
+    return this._search(this, pivot) as ElementBoundary
   }
 
-  private _search(self: KDTree, pivot: Point): Boundary | null {
+  private _search(self: KDTree, pivot: Point): ElementBoundary | null {
     if (!self) {
       return null;
     }
@@ -64,7 +69,7 @@ export class KDTree {
     let nextSubTree: KDTree | null = null;
     let alterateSubTree: KDTree | null = null;
 
-    if (pivot[axis] < self.root[axis]) {
+    if (pivot[axis] < self.root.boundary[axis]) {
       nextSubTree = self.left;
       alterateSubTree = self.right
     } else {
@@ -75,18 +80,17 @@ export class KDTree {
     let closest = getCloserDistance(pivot, nextSubTree?._search(nextSubTree!, pivot)!, self.root)
 
     //search point and spliting point
-    if (getRawDistance(pivot, closest) > Math.abs(pivot[axis] - self.root[axis])) {
+    if (getRawDistance(pivot, closest.boundary) > Math.abs(pivot[axis] - self.root.boundary[axis])) {
       closest = getCloserDistance(pivot, alterateSubTree?._search(alterateSubTree!, pivot)!, closest)
     }
-    return closest as Boundary
+    return closest as ElementBoundary
   }
 }
 
-
-function sort(data: Boundary[], axis: number) {
+function sort(data: ElementBoundary[], axis: number) {
   if (axis <= MAXIMUM_SUPPORTED_DIMENSION) {
-    return data.sort((b1: Boundary, b2: Boundary) => {
-      return b1[axis] - b2[axis]
+    return data.sort((b1: ElementBoundary, b2: ElementBoundary) => {
+      return b1.boundary[axis] - b2.boundary[axis]
     });
   }
 

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -1,0 +1,1 @@
+export * from './traverse'

--- a/src/dom/traverse.ts
+++ b/src/dom/traverse.ts
@@ -1,0 +1,37 @@
+
+// preorder traverse DOM tree
+export function traverse(root?: ParentNode | Node, cb?: (elem: ParentNode | Node | HTMLElement) => void) {
+  if (!root) {
+    return null;
+  }
+
+  if (cb) {
+    cb(root);
+  }
+
+
+  for (let i = 0; i < root?.childNodes?.length; i++) {
+    const childNode = root.childNodes[i];
+    const isValid = checkIsValidNode(childNode)
+    if (!isValid) {
+      continue;
+    }
+    traverse(childNode, cb);
+  }
+
+}
+
+function checkIsValidNode(elem: Node | ParentNode) {
+
+  const invalidTags = ['script', 'head', 'data', 'embed', 'html', 'unknown', 'meta', 'link', 'object', 'script', 'noscript', 'source', 'template', 'track', 'title', 'style', 'link', '#text'
+  ];
+
+  //https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeValue
+  // https://developer.mozilla.org/docs/Web/API/Node/nodeType
+  const isElem = !elem.nodeValue && elem.nodeType === 1;
+  const isValid = !invalidTags.includes(elem.nodeName.toLowerCase())
+
+  return isElem && isValid
+}
+
+traverse(document.body)

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,20 @@ import { Camera } from './camera'
 import { setBackendAndEnvFlags } from './utils';
 import { ClickGestureEvent } from './ClickGestureEvent'
 import { KDTree } from './KDTree';
-import { Boundary2D } from './types';
+import { Boundary2D, ElementBoundary } from './types';
+import { traverse } from './dom/traverse'
+import fastdomPromiseExtension from 'fastdom/extensions/fastdom-promised'
+import Fastdom from 'fastdom';
 
+
+const debug = console.log.bind(console, '[V-Gesture]');
+const fastdom = Fastdom.extend(fastdomPromiseExtension);
 declare global {
   interface Window {
     xr_clickables: any
+  }
+  interface NamedNodeMap {
+    gClickable?: string
   }
 }
 let camera: Camera;
@@ -47,8 +56,7 @@ async function createDetector() {
 
 async function app() {
 
-  init()
-
+  initialize()
   camera = await Camera.setupCamera(STATE.camera);
 
   await setBackendAndEnvFlags(STATE.flags, STATE.backend);
@@ -56,10 +64,6 @@ async function app() {
   detector = await createDetector();
 
   renderPrediction();
-
-
-  Testing()
-
 };
 
 app();
@@ -210,133 +214,62 @@ function getGestureClickDistance(keypoint1: any, keypoint2: any) {
 
 
 
-function init() {
 
-  const CNT = 1000
-  const arr = new Array(CNT).fill(0).map((_, idx) => idx)
 
-  const d: Boundary2D[] = []
-  window.xr_clickables = []
-  for (const i of arr) {
+async function initialize() {
 
-    const btn = document.createElement('div')
-    btn.classList.add('btn')
-    btn.id = `btn-${i}`
-    btn.innerHTML = 'Click me!!!'
-    document.body.appendChild(btn);
-    const bDim = btn?.getBoundingClientRect();
-    const bTop = Math.random() * (window.innerHeight - (bDim!.height / 2));
-    const bLeft = Math.random() * (window.innerWidth - (bDim!.width / 2));
-    (btn as any).style.top = bTop + 'px';
-    (btn as any).style.left = bLeft + 'px';
-    btn.dataset.boundary = JSON.stringify({
-      top: bTop,
-      left: bLeft,
-      dx: bDim!.width,
-      dy: bDim!.height,
+  const PREFIX = 'g-clickable-element-'
+  const elemBoundaries: ElementBoundary[] = []
+  let id = 0;
+
+  await fastdom.mutate(() => {
+    // traverse sub Dom tree root of body node, and find all elems with gClickable specified elements
+    // then create kdtree to handle event target domain
+    traverse(document.body, (elem) => {
+      if ((elem as HTMLElement).hasAttribute('gClickable')) {
+        const clickableElem = elem as HTMLElement
+        const { top, left, width, height } = clickableElem.getBoundingClientRect();
+        let elemId = clickableElem.id;
+
+        if (!elemId) {
+          elemId = `${PREFIX}-${id}`
+          id++;
+        }
+
+        clickableElem.id = elemId;
+
+        const x = left + width / 2;
+        const y = top + height / 2;
+        const dx = width / 2;
+        const dy = height / 2;
+        const boundary = [x, y, dx, dy] as Boundary2D;
+        const ElementBoundary = {
+          id: elemId,
+          dimension: boundary.length / 2,
+          boundary
+        }
+
+        elemBoundaries.push(ElementBoundary)
+      }
     })
 
+    kdTree = new KDTree(elemBoundaries);
+  })
 
-    d.push([bLeft + (bDim!.width / 2), bTop + (bDim!.height / 2), (bDim!.width / 2), (bDim!.height / 2), btn.id])
-
-    kdTree = new KDTree(d);
-
-    window.xr_clickables.push(btn);
-  }
 
 
   const pin = document.getElementById('pin')
 
-  window.clicked = 0;
 
-  window.list = []
 
   window.addEventListener('clickGesture', (e: any) => {
-
-
-
-    // pin!.style.top = (e as any).triggerPoint.y + 'px'
-    // pin!.style.left = (e as any).triggerPoint.x + 'px'
-    // var startTime = performance.now()
-
-
-    // using kd tree
-
+    pin!.style.top = (e as any).triggerPoint.y + 'px'
+    pin!.style.left = (e as any).triggerPoint.x + 'px'
     const nodeId = kdTree.emit([e.triggerPoint.x, e.triggerPoint.y])
     if (nodeId) {
       const node = document.getElementById(nodeId);
-      if (node) {
-        if (!node.flag) {
-          window.clicked++
-        } else {
-          return
-        }
-        node.flag = true
-        node.innerHTML = 'Clicked!!!!'
-        node.style.transition = 'all 0.3s ease';
-        node.style.backgroundColor = '#bb86fc'
-      }
+      node?.dispatchEvent(new Event('click'));
     }
-
-
-    // using array
-    // for (let i = 0; i < window.xr_clickables.length; i++) {
-    //   if (!window.xr_clickables[i].dataset.boundary) {
-    //     continue;
-    //   }
-    //   const boundary = JSON.parse(window.xr_clickables[i].dataset.boundary)
-
-    //   if (isInterior((e as any).triggerPoint, boundary)) {
-
-
-    //     const target = window.xr_clickables[i];
-    //     if (!target.flag) {
-    //       window.clicked++
-    //     } else {
-    //       continue;
-    //     }
-    //     target.flag = true
-    //     target.innerHTML = 'Clicked!!!!'
-    //     target.style.transition = 'all 0.3s ease';
-    //     target.style.backgroundColor = '#bb86fc'
-    //     break
-    //   }
-    // }
-
-    // var endTime = performance.now()
-
-    // console.log(`Call to doSomething took ${endTime - startTime} milliseconds`)
 
   })
-}
-
-function isInterior(point: any, boundary: any) {
-  return point.x >= boundary.left && point.x <= (boundary.left + boundary.dx) && point.y >= boundary.top && point.y <= (boundary.top + boundary.dy)
-
-}
-
-function Testing() {
-  const events: any = new Array(100).fill(0).map((_) => new Array(100).fill(0))
-
-  for (let i = 0; i < 100; i++) {
-    for (let j = 0; j < 100; j++) {
-      events[i][j] = new ClickGestureEvent('clickGesture', {
-        indexTip: { x: i * 12, y: j * 12 },
-        thumbTip: { x: i * 12, y: j * 12 },
-      })
-    }
-  }
-
-
-  var startTime = performance.now()
-
-  for (let i = 0; i < 100; i++) {
-    for (let j = 0; j < 100; j++) {
-      dispatchEvent(events[i][j])
-    }
-  }
-
-  var endTime = performance.now()
-
-  console.log(`10000 execution of clickGesture with k-d tree took ${endTime - startTime} milliseconds`)
 }

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -1,10 +1,10 @@
-import type { Boundary, Point } from '../types'
+import type { Boundary, ElementBoundary, Point } from '../types'
 
 export function getRawDistance(p1: Point | Boundary, p2: Point | Boundary) {
   return Math.pow(p1[0] - p2[0], 2) + Math.pow(p1[1] - p2[1], 2);
 }
 // returns p1 or p2 depending which one is closer to pivot
-export function getCloserDistance(pivot: Point | Boundary, p1: Point | Boundary, p2: Point | Boundary) {
+export function getCloserDistance(pivot: Point | Boundary, p1: ElementBoundary, p2: ElementBoundary) {
   if (!p1) {
     return p2
   }
@@ -12,8 +12,8 @@ export function getCloserDistance(pivot: Point | Boundary, p1: Point | Boundary,
     return p1
   }
 
-  const d1 = getRawDistance(pivot, p1);
-  const d2 = getRawDistance(pivot, p2);
+  const d1 = getRawDistance(pivot, p1.boundary);
+  const d2 = getRawDistance(pivot, p2.boundary);
 
   if (d1 < d2) {
     return p1

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,3 +14,12 @@ export type Boundary3D = [number, number, number, number, number, number];
 
 export type Point = (Vector2D | Vector3D);
 export type Boundary = (Boundary2D | Boundary3D)
+export interface ElementBoundary {
+  id: string;
+  dimension: number;
+  boundary: Boundary;
+}
+
+
+export type RenderedElement<T extends Node> = T
+export type HTMLValidElement = HTMLDivElement | HTMLAnchorElement | HTMLAnchorElement | HTMLAreaElement | HTMLAudioElement | HTMLBRElement | HTMLBaseElement | HTMLBodyElement | HTMLButtonElement | HTMLCanvasElement | HTMLDListElement | HTMLDetailsElement | HTMLDialogElement | HTMLFieldSetElement | HTMLFormControlsCollection | HTMLFormElement | HTMLFrameSetElementEventMap | HTMLHRElement | HTMLHeadingElement | HTMLIFrameElement | HTMLImageElement | HTMLInputElement | HTMLLIElement | HTMLLegendElement | HTMLLabelElement | HTMLLinkElement | HTMLMapElement | HTMLMediaElement | HTMLMenuElement | HTMLObjectElement | HTMLOptGroupElement | HTMLParagraphElement | HTMLPictureElement | HTMLPreElement | HTMLProgressElement | HTMLQuoteElement | HTMLSelectElement | HTMLSlotElement | HTMLSpanElement | HTMLTableCaptionElement | HTMLTableCellElement | HTMLTableColElement | HTMLTableElement | HTMLTableElement | HTMLTableRowElement | HTMLTableSectionElement | HTMLTextAreaElement | HTMLTimeElement | HTMLTitleElement | HTMLTrackElement | HTMLUListElement | HTMLVideoElement | HTMLOrSVGElement | HTMLOrSVGImageElement | Node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -479,6 +479,13 @@ esbuild@^0.20.1:
     "@esbuild/win32-ia32" "0.20.2"
     "@esbuild/win32-x64" "0.20.2"
 
+fastdom@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fastdom/-/fastdom-1.0.12.tgz#ae43d55af017252ae499b2e186511ab97412de39"
+  integrity sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==
+  dependencies:
+    strictdom "^1.0.1"
+
 follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
@@ -648,6 +655,11 @@ source-map-js@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
+
+strictdom@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strictdom/-/strictdom-1.0.1.tgz#189de91649f73d44d59b8432efa68ef9d2659460"
+  integrity sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==
 
 three@0.125:
   version "0.125.2"


### PR DESCRIPTION
## Implementation

- During initialization phase, V-Gesture will recurse DOM subtree which holds `body` as root and try to find all elements with gClickable attribute. (there are some exception elements e.g) script, head, meta etc..) Then, calculate their `elementBoundaryData` and pass it to k-d tree.
- Previously, `getBoundingClientRect` (caused bottleneck)[https://webperf.tips/tip/layout-thrashing/]. To prevent it happen synchronously, used (fastDom)[https://www.npmjs.com/package/fastdom] to make execution async.

## Notes

-

## Etc

- N/A

## Checklist before merge

- N/A
