### PR TITLE
[update] rename attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,29 +94,29 @@ limitations under the License.
     <div id="stats"></div>
     <div id="main">
       <div class="container">
-        <button id="btn0" class="btn" gClickable onclick="alert('clicked! 0')">
+        <button id="btn0" class="btn" vgesturable onclick="alert('clicked! 0')">
           Click ME!!!
         </button>
         <div>
           <button
             id="btn1"
             class="btn"
-            gClickable
+            vgesturable
             onclick="alert('clicked! 1')"
           >
             Click ME!!! 1
           </button>
         </div>
-        <button id="btn2" class="btn" gClickable onclick="alert('clicked! 2')">
+        <button id="btn2" class="btn" vgesturable onclick="alert('clicked! 2')">
           Click ME!!! 2
         </button>
       </div>
     </div>
-    <button id="btn3" class="btn" gClickable onclick="alert('clicked!')">
+    <button id="btn3" class="btn" vgesturable onclick="alert('clicked!')">
       Scroll and Click ME!!! 3
     </button>
 
-    <button id="btn4" class="btn" gClickable onclick="alert('clicked!')">
+    <button id="btn4" class="btn" vgesturable onclick="alert('clicked!')">
       Scroll and Click ME!!! 4
     </button>
   </body>

--- a/src/VGesture.ts
+++ b/src/VGesture.ts
@@ -193,7 +193,7 @@ export class VGesture {
   }
 
   private async _generateGestureTargetCollection() {
-    const PREFIX = 'g-clickable-element'
+    const PREFIX = 'vgesturable'
     const elemBoundaries: ElementBoundary[] = []
     let id = 0;
 
@@ -201,7 +201,7 @@ export class VGesture {
       // traverse from  Dom tree, rooting from body node, find all elems with gClickable specified elements
       // create kdtree to handle event target domain
       traverse(document.body, (elem) => {
-        if ((elem as HTMLElement).hasAttribute('gClickable')) {
+        if ((elem as HTMLElement).hasAttribute('vgesturable')) {
           const clickableElem = elem as HTMLElement
           const { top, left, width, height } = clickableElem.getBoundingClientRect();
           let elemId = clickableElem.id;


### PR DESCRIPTION
## Implementation

- g-clickable-element is really specific name and doesn't fit for current module any more. so rename to `vgesturable`

## Notes

-

## Etc

- N/A

## Checklist before merge

- N/A
